### PR TITLE
Change composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sentry/sentry-php-agent",
+    "name": "sentry/sentry-agent",
     "type": "library",
     "description": "Sentry Agent for PHP (https://sentry.io)",
     "homepage": "https://sentry.io",


### PR DESCRIPTION
This aligns the package name with our other packages on https://packagist.org/packages/sentry/.