### PR TITLE
Forwarder improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "clue/mq-react": "^1.6",
         "react/http": "^1.11",
         "react/socket": "^1.16",
-        "sentry/sentry": "^4.10"
+        "sentry/sentry": "^4.11.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -59,6 +59,11 @@ class Envelope
         return $this->items;
     }
 
+    public function isEmpty(): bool
+    {
+        return empty($this->items);
+    }
+
     /**
      * @param callable(EnvelopeItem): bool $callback if the callback returns true, the item will be removed from the envelope
      */

--- a/src/EnvelopeForwarder.php
+++ b/src/EnvelopeForwarder.php
@@ -72,14 +72,7 @@ class EnvelopeForwarder
         $rateLimiter = $this->getRateLimiter($dsn);
 
         $envelope->rejectItems(static function (EnvelopeItem $envelopeItem) use ($rateLimiter) {
-            $envelopeItemType = $envelopeItem->getItemType();
-
-            // @TODO: We should make the rate limiter accept an arbitrary item type to allow for flexibility when adding new item types
-            if ($envelopeItemType === null) {
-                return false;
-            }
-
-            return $rateLimiter->isRateLimited($envelopeItemType);
+            return $rateLimiter->isRateLimited($envelopeItem->getHeader()['type']);
         });
 
         // @TODO: If we rate limit all the items we have an empty envelope which we should not send and just return

--- a/src/EnvelopeItem.php
+++ b/src/EnvelopeItem.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\Agent;
 
-use Sentry\EventType;
-
 /**
  * @internal
  *
@@ -41,20 +39,6 @@ class EnvelopeItem
     public function getHeader(): array
     {
         return $this->header;
-    }
-
-    public function getItemType(): ?EventType
-    {
-        switch ($this->header['type']) {
-            case (string) EventType::event():
-                return EventType::event();
-            case (string) EventType::transaction():
-                return EventType::transaction();
-            case (string) EventType::checkIn():
-                return EventType::checkIn();
-            default:
-                return null;
-        }
     }
 
     public function getData(): string


### PR DESCRIPTION
Resolve two TODO's:

- Rate limiter is now able to rate-limit any envelope item (even if unknown)
- When an envelope is empty (because all items are rate limited) the envelope is not sent