### PR TITLE
chore: Use pull_request_target for changelog preview

### DIFF
--- a/.github/workflows/changelog-preview.yml
+++ b/.github/workflows/changelog-preview.yml
@@ -1,6 +1,6 @@
 name: Changelog Preview
 on:
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - synchronize


### PR DESCRIPTION
## Summary

Updates the changelog-preview workflow to use `pull_request_target` instead of `pull_request`.

## Why?

This change is required for the changelog preview to work correctly with PRs from forks. With `pull_request`, the workflow runs with a read-only `GITHUB_TOKEN` which cannot post comments or create statuses on fork PRs.

This aligns with the recommended usage in the [craft changelog-preview workflow](https://github.com/getsentry/craft/blob/master/.github/workflows/changelog-preview.yml).

## Security Note

This change is safe because the changelog-preview workflow:
- Downloads the Craft binary from releases (not from the PR)
- Only reads git metadata and configuration  
- Does not execute any code from the PR